### PR TITLE
有効値確認処理を追加

### DIFF
--- a/include/push_swap.h
+++ b/include/push_swap.h
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/23 20:32:57 by ttsubo            #+#    #+#             */
-/*   Updated: 2024/12/23 22:22:07 by ttsubo           ###   ########.fr       */
+/*   Updated: 2024/12/24 11:52:14 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,12 @@ typedef enum e_stack_type
 	STACK_B,
 	STACK_BOTH,
 }		t_stack_type;
+
+typedef enum e_psh_swp_sts
+{
+	PSH_SWP_OK,
+	PSH_SWP_NG,
+}		t_psh_swp_sts;
 
 // prototype
 void	swap(int *stack, t_stack_type type);

--- a/src/main.c
+++ b/src/main.c
@@ -6,16 +6,82 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/23 20:47:52 by ttsubo            #+#    #+#             */
-/*   Updated: 2024/12/23 22:21:53 by ttsubo           ###   ########.fr       */
+/*   Updated: 2024/12/24 15:14:28 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "push_swap.h"
 
+static int	ft_atoi_with_error(const char *str, int *error)
+{
+	long int	sign;
+	long int	num;
+
+	sign = 1;
+	num = 0;
+	*error = 0;
+	while (*str == ' ')
+		str++;
+	if (*str == '-')
+		sign = -1;
+	if (*str == '+' || *str == '-')
+		str++;
+	while (ft_isdigit(*str))
+	{
+		num = num * 10 + (*str - '0');
+		if (num * sign > INT_MAX || num * sign < INT_MIN)
+			return (*error = 1, 0);
+		str++;
+	}
+	if (*str != '\0')
+		return (*error = 1, 0);
+	return ((int)(sign * num));
+}
+
+static char	**free_tokens(char **tokens, size_t index)
+{
+	while (index > 0)
+		free(tokens[--index]);
+	free(tokens);
+	return (NULL);
+}
+
+/**
+ * @brief
+ *
+ * @param arg
+ * @return int
+ */
+static t_psh_swp_sts	validate_input(char *input)
+{
+	char	**tokens;
+	int		error;
+	int		value;
+	int		i;
+
+	tokens = ft_split(input, ' ');
+	if (!tokens)
+		return (PSH_SWP_NG);
+	i = 0;
+	while (tokens[i] != NULL)
+	{
+		error = 0;
+		value = ft_atoi_with_error(tokens[i], &error);
+		if (error)
+			return (free_tokens(tokens, i), PSH_SWP_NG);
+		i++;
+	}
+	free_tokens(tokens, i);
+	return (PSH_SWP_OK);
+}
+
 int	main(int argc, char **argv)
 {
 	(void)argc;
 	(void)argv;
-	ft_printf("test");
+	if (validate_input(argv[1]) == 0)
+		ft_printf("OK");
+	else
+		ft_printf("NG");
 	return (0);
 }


### PR DESCRIPTION
fixed #3 
ft_splitとpush_swap用のft_atoiを作成して対応

`1 2 3`や`-23245 56789 0`は問題ない
`1 2 3 `などはエラーは出ないが空白だけなので許容する。

